### PR TITLE
Add Hugging Face integration

### DIFF
--- a/models/base_cwm/modeling_pretrain.py
+++ b/models/base_cwm/modeling_pretrain.py
@@ -1,6 +1,8 @@
 import os
 from functools import partial
 
+from huggingface_hub import PyTorchModelHubMixin
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -33,7 +35,11 @@ def interpolate_pos_encoding(pos_embed, n_frames, h, w):
     return patch_pos_embed.permute(0, 2, 3, 1).flatten(0, 2).unsqueeze(0)
 
 
-class PretrainVisionTransformerEncoder(nn.Module):
+class PretrainVisionTransformerEncoder(nn.Module,
+                                       PyTorchModelHubMixin,
+                                       repo_url="https://github.com/neuroailab/Opt_CWM",
+                                       pipeline_tag="image-feature-extraction",
+                                       license="mit"):
     """Vision Transformer with support for patch or hybrid CNN input stage"""
 
     def __init__(


### PR DESCRIPTION
This PR proposes 2 things:

- add `from_pretrained` and `push_to_hub` capabilities to the `PretrainVisionTransformerEncoder` class, by inheriting from the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/en/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class. Bonus: safetensors serialization, model card and download stats
- add a custom `from_pretrained` method to the main `FlowPredictor` class. This one is custom since it requires to take various nn.Modules at init.

